### PR TITLE
Dead Zone for Stick Input and prevent camera from "rolling over"

### DIFF
--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -187,6 +187,26 @@ void sceneUpdate(struct Scene* scene) {
     struct Quaternion tempRotation;
     quatMultiply(&deltaRotate, &scene->camera.transform.rotation, &tempRotation);
 
+    // Define a threshold for the comparison (adjust this value as needed)
+    float upThreshold = 0.99f; // This value should be close to 1.0 for a strict check
+
+    // Calculate the camera's forward direction in world space
+    struct Vector3 cameraForward;
+    quatRotate(&scene->camera.transform.rotation, &gForward, &cameraForward);
+    
+    // Prevent camera from "rolling over"
+    if (cameraForward.y >= upThreshold) {
+        // Camera is pointing down
+        if (stickY <= 0) {
+            stickY = 0.0f; // Disable downward movement
+        }
+    } else if (-cameraForward.y >= upThreshold) {
+        // Camera is pointing up
+        if (stickY >= 0) {
+            stickY = 0.0f; // Disable upward movement
+        }
+    }
+
     // pitch
     quatAxisAngle(&gRight, stickY * ROTATE_SPEED * FIXED_DELTA_TIME * (1.0f / 80.0f), &deltaRotate);
     quatMultiply(&tempRotation, &deltaRotate, &scene->camera.transform.rotation);

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -165,14 +165,30 @@ void sceneUpdate(struct Scene* scene) {
 
     OSContPad* pad = controllersGetControllerData(0);
 
+    // Define a deadzone threshold (adjust this value as needed)
+    float deadzoneThreshold = 10.0f;
+
+    // Apply deadzone to stick input
+    float stickX = pad->stick_x;
+    float stickY = pad->stick_y;
+
+    // Ignore values within the deadzone
+    if (stickX >= -deadzoneThreshold && stickX <= deadzoneThreshold) {
+        stickX = 0.0f; // Ignore small stick movements
+    }
+
+    if (stickY >= -deadzoneThreshold && stickY <= deadzoneThreshold) {
+        stickY = 0.0f; // Ignore small stick movements
+    }
+
     // yaw
     struct Quaternion deltaRotate;
-    quatAxisAngle(&gUp, -pad->stick_x * ROTATE_SPEED * FIXED_DELTA_TIME * (1.0f / 80.0f), &deltaRotate);
+    quatAxisAngle(&gUp, -stickX * ROTATE_SPEED * FIXED_DELTA_TIME * (1.0f / 80.0f), &deltaRotate);
     struct Quaternion tempRotation;
     quatMultiply(&deltaRotate, &scene->camera.transform.rotation, &tempRotation);
 
     // pitch
-    quatAxisAngle(&gRight, pad->stick_y * ROTATE_SPEED * FIXED_DELTA_TIME * (1.0f / 80.0f), &deltaRotate);
+    quatAxisAngle(&gRight, stickY * ROTATE_SPEED * FIXED_DELTA_TIME * (1.0f / 80.0f), &deltaRotate);
     quatMultiply(&tempRotation, &deltaRotate, &scene->camera.transform.rotation);
 
     scene->verticalVelocity += GRAVITY * FIXED_DELTA_TIME;


### PR DESCRIPTION
* Added a small amount of "dead zone" for the sticks, so the old n64 controllers do not drift so much 
* Added a check that prevents the camera from going beyond looking straight up or down 
🖤